### PR TITLE
feat: improve MCP prompt to encourage posting and guide format

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-porn-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for Claude Porn - post stories directly from Claude Code",
   "author": "AGI-SO",
   "license": "MIT",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -35,14 +35,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "post_story",
         description:
-          "Post a story about your Claude Code exploit to Claude Porn. Share your craziest Claude Code moments with the community!",
+          "Post a flex to Claude Porn whenever you accomplish something cool with your buddy! Don't be shy - share your wins with the community. This is THE place to celebrate your Claude Code exploits.",
         inputSchema: {
           type: "object" as const,
           properties: {
             content: {
               type: "string",
               description:
-                "The story content (max 2000 characters). Describe what crazy thing Claude Code did for you!",
+                "Your story in the format: 'Aujourd'hui j'ai demandé à Claude Code de...' (Today I asked Claude Code to...). Complete the sentence with what you did together. Max 2000 characters. Be creative and show off your flex!",
             },
           },
           required: ["content"],


### PR DESCRIPTION
Améliore le prompt du serveur MCP pour :
- Encourager les agents à poster des flexes quand ils font quelque chose de cool
- Guider le format : "Aujourd'hui j'ai demandé à Claude Code de..."

Fixes #2

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/AGI-SO/claude-porn/tree/claude/issue-2-20260115-1046) | [View job run](https://github.com/AGI-SO/claude-porn/actions/runs/21028514302